### PR TITLE
feat: add sync mutex to manage file write in goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # logwriter
 
-logwriter is a simple Go package for writing log messages to a file.
+`logwriter` is a simple Go package for writing log messages to a file. It is safe for use with goroutines, allowing multiple goroutines to write to the log file concurrently without causing race conditions.
 
 ## Installation
 
@@ -34,6 +34,41 @@ func main() {
     if err != nil {
         log.Fatalf("Failed to write to log file: %v", err)
     }
+}
+```
+
+## Goroutine Safety
+
+The logwriter package is safe for use with goroutines. You can safely use the same logWriter instance across multiple goroutines. Here is an example demonstrating concurrent writes:
+
+```go
+package main
+
+import (
+    "log"
+    "sync"
+    "github.com/yourusername/logwriter"
+)
+
+func main() {
+    lw, err := logwriter.NewLogWriter("logfile.log")
+    if err != nil {
+        log.Fatalf("Failed to create log writer: %v", err)
+    }
+    defer lw.Close()
+
+    var wg sync.WaitGroup
+    for i := 0; i < 10; i++ {
+        wg.Add(1)
+        go func(i int) {
+            defer wg.Done()
+            err := lw.Write(fmt.Sprintf("Log message from goroutine %d\n", i))
+            if err != nil {
+                log.Printf("Failed to write log message: %v", err)
+            }
+        }(i)
+    }
+    wg.Wait()
 }
 ```
 

--- a/logwriter.go
+++ b/logwriter.go
@@ -1,9 +1,13 @@
 package logwriter
 
-import "os"
+import (
+	"os"
+	"sync"
+)
 
 type LogWriter struct {
 	file *os.File
+	mu   sync.Mutex
 }
 
 func NewLogWriter(filename string) (*LogWriter, error) {
@@ -15,10 +19,14 @@ func NewLogWriter(filename string) (*LogWriter, error) {
 }
 
 func (l *LogWriter) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	return l.file.Close()
 }
 
 func (l *LogWriter) Write(text string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	_, err := l.file.WriteString(text)
 	return err
 }


### PR DESCRIPTION
This PR enhances the logwriter package to be safe for use with goroutines. By introducing a mutex (sync.Mutex), we ensure that concurrent writes to the log file do not cause race conditions. This improvement allows multiple goroutines to safely write to the same log file simultaneously.